### PR TITLE
Prevent trying to register abstract classes

### DIFF
--- a/Superscribe.WebAPI/SuperscribeConfig.cs
+++ b/Superscribe.WebAPI/SuperscribeConfig.cs
@@ -25,7 +25,9 @@
 
             var modules = (from assembly in AppDomain.CurrentDomain.GetAssemblies()
                            from type in assembly.GetTypes()
-                           where typeof(SuperscribeModule).IsAssignableFrom(type) && type != typeof(SuperscribeModule)
+                           where !type.IsAbstract
+                           && typeof(SuperscribeModule).IsAssignableFrom(type)
+                           && type != typeof(SuperscribeModule)
                            select new { Type = type }).ToList();
 
             foreach (var module in modules)


### PR DESCRIPTION
This is still an issue and prevents being able to just reference Superscribe via the nuget package.
Even if the project is not actively maintained any more, can this be added in?
It's just a safeguard to prevent exceptions when an assembly contains any abstract SuperscribeModule classes